### PR TITLE
added missing exception include.

### DIFF
--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -19,6 +19,7 @@ use Psr\Log\LoggerInterface;
 use ElephantIO\EngineInterface;
 use ElephantIO\Payload\Decoder;
 use ElephantIO\Exception\UnsupportedActionException;
+use ElephantIO\Exception\MalformedUrlException;
 
 abstract class AbstractSocketIO implements EngineInterface
 {


### PR DESCRIPTION
parseUrl($url) throws MalformedUrlException if url is invalid.. due to missing exception type include, this fails.
